### PR TITLE
Use new API URL

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -2,7 +2,7 @@ import axios from 'axios';
 import chalk from 'chalk';
 
 const cwb = {
-  baseUrl: 'https://opendata.cwb.gov.tw/api/v1/rest/datastore',
+  baseUrl: 'https://opendata.cwa.gov.tw/api/v1/rest/datastore',
   key: process.env.CWB_KEY,
   dataId: 'F-D0047-055',
 };


### PR DESCRIPTION
The current URL is no longer available (starting from Jan 1 2024):

>  氣象會員網站異動公告：配合本署改制後cwb舊網址https://pweb.cwb.gov.tw/網址將於113年1月1日起失效，請各位會員使用cwa 新網址 https://pweb.cwa.gov.tw/。造成不便，敬請見諒。